### PR TITLE
爆弾の配置

### DIFF
--- a/src/styles/components/pages/Top.scss
+++ b/src/styles/components/pages/Top.scss
@@ -1,6 +1,7 @@
 .wrapper {
   margin: 0;
-  padding: 30px;
+  padding: 30px 0;
+  text-align: center;
 
   .title {
     display: flex;

--- a/src/styles/components/templates/Board.scss
+++ b/src/styles/components/templates/Board.scss
@@ -6,16 +6,17 @@
 }
 
 .board {
+  display: inline-block;
+
   .row {
     display: flex;
-    align-items: center;
-    justify-content: center;
 
     .cell {
       display: flex;
       align-items: center;
       justify-content: center;
       width: 25px;
+      min-width: 25px;
       height: 25px;
       background-color: #d3d3d3;
       border: 4px outset white;
@@ -27,7 +28,12 @@
       &.open {
         border: 1px solid #a9a9a9;
         width: 31px;
+        min-width: 31px;
         height: 31px;
+
+        &.bomb {
+          background-color: red;
+        }
       }
 
       &:not(.open) {


### PR DESCRIPTION
fix #4 

- 各マスにランダムで爆弾を配置する
- 最初に選択したマスが爆弾の場合、爆弾の無い最初のマスに移動させる

![スクリーンショット 2020-01-06 1 20 38](https://user-images.githubusercontent.com/30336118/71782923-08ed9d00-3023-11ea-9d4e-79653412ebcb.png)
